### PR TITLE
Replace React.memo with export default

### DIFF
--- a/src/components/PhotoFeed.js
+++ b/src/components/PhotoFeed.js
@@ -3,8 +3,5 @@ import PropTypes from "prop-types";
 import Photo from "./Photo";
 import { Col, Row } from "antd";
 
-
-// TODO-1
-
-export default React.memo();
+//TODO-1 export default PhotoFeed;
 


### PR DESCRIPTION
This commit replaces React.memo with export default <Component> since the result will no longer be a functional component.